### PR TITLE
put DB get queries in service-layer and implement in FrontPage

### DIFF
--- a/src/FrontPage.jsx
+++ b/src/FrontPage.jsx
@@ -4,69 +4,18 @@ import "./index.css";
 import Parse from "parse";
 import DetailPage from "./pages/DetailPage/Detailpage";
 import Loading from "./toasts/Loading";
-
-
+import getEvents from "./services/GetEventsService.js";
 
 export default function FrontPage() {
   const [events, setEvents] = useState([]);
   const [selectedEvent, setSelectedEvent] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
-
   useEffect(() => {
     async function loadEvents() {
-      let formattedJSON = [];
-
-      try {
-        const Event = Parse.Object.extend("Event");
-        const query = new Parse.Query(Event);
-
-        //how we fetch the rows of the foreign keys
-        query.ascending("startDate", "startTime");
-        query.include("orgID");
-        query.include("eventPicID");
-
-        const results = await query.find();
-
-        console.log(`Fetched ${results.length} events from Back4App`);
-
-        formattedJSON = await Promise.all(
-          results.map(async (eventObj) => {
-            //pointers
-            const org = eventObj.get("orgID");
-            const pic = eventObj.get("eventPicID");
-
-            //relation
-            let tags = [];
-            const tagRelation = eventObj.relation("eventTag");
-            if (tagRelation) {
-              tags = (await tagRelation.query().find()).map((tag) =>
-                tag.get("term")
-              );
-            }
-
-            return {
-              id: eventObj.id,
-              title: eventObj.get("title"),
-              description: eventObj.get("description"),
-              startTime: eventObj.get("startTime"),
-              endTime: eventObj.get("endTime"),
-              signupLink: eventObj.get("signupLink"),
-              organisation: org?.get("orgName") ?? "unknown organisation",
-              img:
-                pic?.get("fileName")?.url() ??
-                "src/assets/thumbnail-default.png",
-              tags,
-            };
-          })
-        );
-      } catch (error) {
-        console.error("Error loading events:", error);
-        setIsLoading(false);
-      }
-     setIsLoading(false);
-
-     setEvents(formattedJSON); //adds JSON data to useState([])
+      const eventData = await getEvents();
+      setEvents(eventData);
+      setIsLoading(false);
     }
     loadEvents();
   }, []); //dependency array is empty, but needs connection to FilterSidebar eventually
@@ -75,7 +24,9 @@ export default function FrontPage() {
     <>
       <section className="grid-container">
         <div className="event-count">
-          <h2>{events.length < 1 ? "" : "Events " + "(" + events.length +")"}</h2>
+          <h2>
+            {events.length < 1 ? "" : "Events " + "(" + events.length + ")"}
+          </h2>
         </div>
         {isLoading && <Loading text="Loading events..." />}
 

--- a/src/services/GetEventsService.js
+++ b/src/services/GetEventsService.js
@@ -1,0 +1,56 @@
+import Parse from "parse";
+
+export default async function getEvents(filters = {}) {
+  const Event = Parse.Object.extend("Event");
+  const query = new Parse.Query(Event);
+
+  query.ascending("startDate", "startTime");
+  query.include("orgID");
+  query.include("eventPicID");
+
+  // Filters to use when querying DB for events
+
+  //filter on start date greater than or equal to today
+  if (filters.onlyFuture) {
+    query.greaterThanOrEqualTo("startDate", new Date());
+  }
+
+  // filter on orgs with specific orgID
+  if (filters.organisationId) {
+    const Org = Parse.Object.extend("Organisation");
+    const orgPointer = Org.createWithoutData(filters.organisationId);
+    query.equalTo("orgID", orgPointer);
+  }
+
+  //filter on events with specific tags
+  if (filters.tags?.length) {
+    query.containedIn("eventTag", filters.tags);
+  }
+
+  const results = await query.find();
+
+  return Promise.all(
+    results.map(async (eventObj) => {
+      const org = eventObj.get("orgID");
+      const pic = eventObj.get("eventPicID");
+
+      let tags = [];
+      const tagRelation = eventObj.relation("eventTag");
+      if (tagRelation) {
+        tags = (await tagRelation.query().find()).map((t) => t.get("term"));
+      }
+
+      return {
+        id: eventObj.id,
+        title: eventObj.get("title"),
+        description: eventObj.get("description"),
+        startTime: eventObj.get("startTime"),
+        endTime: eventObj.get("endTime"),
+        signupLink: eventObj.get("signupLink"),
+        organisation: org?.get("orgName") ?? "unknown organisation",
+        img: pic?.get("fileName")?.url() ?? "src/assets/thumbnail-default.png",
+        tags,
+      };
+    })
+  );
+}


### PR DESCRIPTION
New implementation used in front-page.
Functionality for filters (onFuture, orgID, tags) also added